### PR TITLE
Add admin command for Cloudinary Images migration

### DIFF
--- a/account/management/commands/cloudinary_migration.py
+++ b/account/management/commands/cloudinary_migration.py
@@ -292,7 +292,7 @@ class Command(BaseCommand):
             migration = CloudinaryMigration(options['model'])
             app_label, model_name = model_path
             model = apps.get_model(app_label, model_name)
-            url_model_map = migration.collect_urls_from_model(model, options['field'], options['model'])
+            url_model_map = migration.collect_urls_from_model(model, options['model'], options['field'])
             self.stdout.write(self.style.SUCCESS(f"Collected {len(url_model_map)} URLs from {model_name}"))
 
         elif command == 'migrate-batch':

--- a/account/management/commands/cloudinary_migration.py
+++ b/account/management/commands/cloudinary_migration.py
@@ -248,6 +248,13 @@ class CloudinaryMigration:
 
         return { 'success': updated_count, 'failed': failed_count }
 
+    def cleanup(self):
+        """Clean up temporary files"""
+        if os.path.exists(self.temp_dir):
+            import shutil
+            shutil.rmtree(self.temp_dir)
+            self.stdout(f"Cleaned up temporary directory: {self.temp_dir}")
+
 
 class Command(BaseCommand):
     help = 'Cloudinary migration utility'
@@ -272,6 +279,9 @@ class Command(BaseCommand):
         # Update model instances
         update_models_parser = subparsers.add_parser('update-models', help='Update model instances with new URLs')
         migrate_parser.add_argument('model', help='Model name (app.ModelName)')
+
+        # Cleanup
+        subparsers.add_parser('cleanup', help='Clean up temporary files')
 
     def handle(self, *args, **options):
         command = options['command']
@@ -304,3 +314,11 @@ class Command(BaseCommand):
             result = migration.update_model_instances(model)
 
             self.stdout.write(self.style.SUCCESS(''))
+
+        elif command == 'cleanup':
+            migration = CloudinaryMigration('None.None')
+            migration.cleanup()
+            self.stdout.write(self.style.SUCCESS('Cleanup completed'))
+
+        else:
+            self.stdout.write(self.style.ERROR('Unknown command'))

--- a/account/management/commands/cloudinary_migration.py
+++ b/account/management/commands/cloudinary_migration.py
@@ -191,11 +191,6 @@ class CloudinaryMigration:
                 self.state['failed_migrations'][instance_id] = self.state['failed_migrations'].get(instance_id, {})
                 self.state['failed_migrations'][field_name] = result['original_url']
 
-        # Update models with new URLs
-        app_label, model_name = self.state['model_path'].split('.')
-        model = apps.get_model(app_label, model_name)
-        self.update_model_instances(model, self.state)
-
         # Update last processed index
         self.state['last_processed_url_index'] = start_index + len(url_model_map)
 

--- a/account/management/commands/cloudinary_migration.py
+++ b/account/management/commands/cloudinary_migration.py
@@ -14,12 +14,13 @@ class CloudinaryMigration:
     """
     Class to handle the phased migration of Cloudinary images from one acount to another.
     """
-    def __init__(self, model_path, batch_size=30, parallel_workers=5):
-        cloudinary.config(
-            cloud_name=settings.TARGET_CLOUDINARY_CLOUD_NAME,
-            api_key=settings.TARGET_CLOUDINARY_API_KEY,
-            api_secret=settings.TARGET_CLOUDINARY_API_SECRET
-        )
+    def __init__(self, model_path, batch_size=30, target=False, parallel_workers=5):
+        if target:
+            cloudinary.config(
+                cloud_name=settings.TARGET_CLOUDINARY_CLOUD_NAME,
+                api_key=settings.TARGET_CLOUDINARY_API_KEY,
+                api_secret=settings.TARGET_CLOUDINARY_API_SECRET
+            )
 
         # Temporary directory for downloads
         self.temp_dir = os.path.join(settings.BASE_DIR, 'temp_cloudinary_images')
@@ -299,7 +300,7 @@ class Command(BaseCommand):
             self.stdout.write(self.style.SUCCESS(f"Collected {len(url_model_map)} URLs from {model_name}"))
 
         elif command == 'migrate-batch':
-            migration = CloudinaryMigration(options['model'])
+            migration = CloudinaryMigration(options['model'], target=True)
             start_index = options.get('start')
             success = migration.migrate_batch(start_index)
 

--- a/account/management/commands/cloudinary_migration.py
+++ b/account/management/commands/cloudinary_migration.py
@@ -1,15 +1,18 @@
 from django.core.management.base import BaseCommand
 from django.conf import settings
 import cloudinary
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 import json
 import os
+import re
+import requests
 
 class CloudinaryMigration:
     """
     Class to handle the phased migration of Cloudinary images from one acount to another.
     """
-    def __init__(self):
+    def __init__(self, batch_size=30):
         cloudinary.config(
             cloud_name=settings.TARGET_CLOUDINARY_CLOUD_NAME,
             api_key=settings.TARGET_CLOUDINARY_API_KEY,
@@ -22,7 +25,8 @@ class CloudinaryMigration:
 
         # Migration state tracking
         self.state_file = os.path.join(settings.BASE_DIR, 'migration_state.json')
-        
+        self.batch_size = batch_size
+
         # Initialize state
         self.load_state()
         
@@ -34,10 +38,12 @@ class CloudinaryMigration:
         else:
             self.state = {
                 'status': 'pending',
+                'last_processed_url_index': 0,
                 'last_updated': datetime.now().isoformat(),
                 'field_name': '',
                 'app_label': '',
                 'url_model_map': [],
+                'successful_migrations': [],
                 'failed_migrations': []
             }
         self.save_state()
@@ -67,6 +73,144 @@ class CloudinaryMigration:
 
         return url_model_map
 
+    def extract_info_from_url(self, url):
+        """Extract public ID and extension from Cloudinary URL
+        """
+        parts = url.split('/')
+        filename = parts[-1].split('?')[0] # Remove any query parameters
+
+        if '.' not in filename:
+            return {
+                'public_id': filename,
+                'extension': 'jpg' # Default extension if not specified
+            }
+        
+        # Try regex pattern for standard Cloudinary URLs
+        regex = r'/v\d+/([^/]+)\.(\w+)(?:\?|$)'
+        match = re.search(regex, url)
+        if match:
+            return {
+                'public_id': match.group(1),
+                'extension': match.group(2)
+            }
+        
+        # Fallback if regex doesn't match
+        if '.' in filename:
+            public_id = '.'.join(filename.split('.')[:-1])
+            extension = filename.split('.')[-1]
+        else:
+            public_id = filename
+            extension = 'jpg'
+
+        return {
+            'public_id': public_id,
+            'extension': extension
+        }
+
+
+    def download_image(self, url, index):
+        """Download an image from a URL"""
+        try:
+            info = self.extract_info_from_url()
+            temp_path = os.path.join(self.temp_dir, f"{info['public_id']}.{info['extension']}")
+
+            response = requests.get(url, stream=True, timeout=30)
+            if response.status_code != 200:
+                raise Exception(f"Failed to download")
+            
+            with open(temp_path, 'wb') as f:
+                for  chunk in response.iter_content(chunk_size=8192):
+                    f.write(chunk)
+
+                return temp_path, info
+        except Exception as e:
+            return None, None
+        
+    def upload_image(self, temp_path, info, original_url, index):
+        """Upload image to new Cloudinary account"""
+        if not temp_path:
+            return False, None
+        
+        try:
+            upload_result = cloudinary.uploader.upload(
+                temp_path,
+                public_id=info['public_id'],
+                resource_type='auto',
+                overwrite=True
+            )
+            return True, upload_result['secure_url']
+        except Exception as e:
+            return False, None
+        finally:
+            if os.path.exists(temp_path):
+                os.remove(temp_path)
+
+    def process_single_url(self, url_data):
+        """Process a single URL, for parallel execution"""
+        index, data = url_data
+        temp_path, info = self.download_image(data.url, index)
+        if temp_path:
+            success, new_url = self.upload_image(temp_path, info, data.url, index)
+            return {
+                'index': index,
+                'success': success,
+                'new_url': new_url,
+                'instance_id': data.instance_id
+            }
+        
+        return {
+            'index': index,
+            'success': False,
+            'new_url': None,
+            'instance_id': data.instance_id
+        }
+
+    def migrate_batch(self, start_index=None):
+        """Migrate a batch of URLs"""
+        if start_index is None:
+            start_index = self.state['last_processed_url_index']
+        url_model_map = self.state['url_model_map'][start_index : start_index + self.batch_size]
+
+        # Create a list of (index, url_model_map[index]) tuples for parallel processing
+        url_data = [(i + start_index, data) for i, data in enumerate(url_model_map)]
+
+        # Process URLs in parallel
+        with ThreadPoolExecutor(max_workers=self.parallel_workers) as executor:
+            results = list(executor.map(self.process_single_url, url_data))
+
+        model_updates = []
+        for result in results:
+            if result['success']:
+                self.state['successful_migrations'].append({
+                    'instance_id': result['instance_id'],
+                    'new_url': result['new_url']
+                })
+                if result['new_url']:
+                    model_updates.append({
+
+                    })
+            else:
+                self.state['failed_migrations'].append({
+                    'instance_id': result['instance_id'],
+                    'original_url': result['original_url']
+                })
+
+        # Update models with new URLs
+        self.update_model_instances(model_updates)
+
+        # Update last processed index
+        self.state['last_processed_url_index'] = start_index + len(url_model_map)
+
+        # Check if this batch is done
+        if self.state['last_processed_url_index'] >= len(self.state['url_model_map']):
+            self.state['status'] = 'completed'
+        else:
+            self.state['status'] = 'in_progress'
+
+        self.save_state()
+
+        return True
+
 
 class Command(BaseCommand):
     help = 'Cloudinary migration utility'
@@ -81,6 +225,10 @@ class Command(BaseCommand):
         collect_model_parser = subparsers.add_parser('collect-model', help='Collect URLs from Django model')
         collect_model_parser.add_argument('model', help='Model name (app.ModelName)')
         collect_model_parser.add_argument('field', help='Field name containing Cloudinary URLs')
+
+        # Migrate in batches
+        migrate_parser = subparsers.add_parser('migrate-batch', help='Migrate a batch of URLs')
+        migrate_parser.add_argument('--start', type=int, help='Start index (default: continue from last batch)')
 
     def handle(self, *args, **options):
         command = options['command']
@@ -100,3 +248,10 @@ class Command(BaseCommand):
             model = apps.get_model(app_label, model_name)
             url_model_map = migration.collect_urls_from_model(model, options['field'], app_label)
             self.stdout.write(self.style.SUCCESS(f"Collected {len(url_model_map)} URLs from {model_name}"))
+
+        elif command == 'migrate-batch':
+            migration = CloudinaryMigration()
+            start_index = options.get('start')
+            success = migration.migrate_batch(start_index)
+
+

--- a/account/management/commands/cloudinary_migration.py
+++ b/account/management/commands/cloudinary_migration.py
@@ -68,6 +68,8 @@ class CloudinaryMigration:
         url_model_map = []
         for obj in queryset:
             image = getattr(obj, field_name)
+            if not image: # Skip if instance has no image for this field
+                continue
             url_model_map.append({
                 'url': image.url,
                 'instance_id': obj.pk

--- a/account/management/commands/cloudinary_migration.py
+++ b/account/management/commands/cloudinary_migration.py
@@ -208,14 +208,17 @@ class CloudinaryMigration:
 
         return True
 
-    def update_model_instances(self, model_class):
+    def update_model_instances(self):
         """Update model instances with new URLs"""
         updated_count = 0
         failed_count = 0
         successful_migrations = self.state['successful_migrations']
 
+        app_label, model_name = self.state['model_path'].split('.')
+        model_class = apps.get_model(app_label, model_name)
+
         # Fetch all instances at once
-        instance_ids = successful_migrations.values()
+        instance_ids = [int(id) for id in successful_migrations.keys()]
         instance_dict = {
             str(instance.pk): instance for instance in model_class.objects.filter(pk__in=instance_ids)
         }
@@ -308,9 +311,7 @@ class Command(BaseCommand):
 
         elif command == 'update-models':
             migration = CloudinaryMigration(options['model'])
-            app_label, model_name = self.state['model_path'].split('.')
-            model = apps.get_model(app_label, model_name)
-            result = migration.update_model_instances(model)
+            result = migration.update_model_instances()
 
             self.stdout.write(self.style.SUCCESS(''))
 

--- a/account/management/commands/cloudinary_migration.py
+++ b/account/management/commands/cloudinary_migration.py
@@ -256,7 +256,8 @@ class CloudinaryMigration:
                         if field_name == 'updated':
                             continue
 
-                        setattr(instance, field_name, new_url)
+                        match = re.search(r'/upload/v\d+/(.+?)(?:\?|$)', new_url)
+                        setattr(instance, field_name, match.group(1))
                         updated = True
 
                     if updated:

--- a/account/management/commands/cloudinary_migration.py
+++ b/account/management/commands/cloudinary_migration.py
@@ -273,7 +273,7 @@ class Command(BaseCommand):
 
         # Update model instances
         update_models_parser = subparsers.add_parser('update-models', help='Update model instances with new URLs')
-        migrate_parser.add_argument('model', help='Model name (app.ModelName)')
+        update_models_parser.add_argument('model', help='Model name (app.ModelName)')
 
         # Cleanup
         subparsers.add_parser('cleanup', help='Clean up temporary files')

--- a/account/management/commands/cloudinary_migration.py
+++ b/account/management/commands/cloudinary_migration.py
@@ -14,7 +14,7 @@ class CloudinaryMigration:
     """
     Class to handle the phased migration of Cloudinary images from one acount to another.
     """
-    def __init__(self, model_path, batch_size=30):
+    def __init__(self, model_path, batch_size=30, parallel_workers=5):
         cloudinary.config(
             cloud_name=settings.TARGET_CLOUDINARY_CLOUD_NAME,
             api_key=settings.TARGET_CLOUDINARY_API_KEY,
@@ -29,6 +29,7 @@ class CloudinaryMigration:
         model_path = model_path.replace('.', '_')
         self.state_file = os.path.join(settings.BASE_DIR, f'{model_path}_migration_state.json')
         self.batch_size = batch_size
+        self.parallel_workers = parallel_workers
 
         # Initialize state
         self.load_state()

--- a/account/management/commands/cloudinary_migration.py
+++ b/account/management/commands/cloudinary_migration.py
@@ -1,0 +1,39 @@
+from django.core.management.base import BaseCommand
+from django.conf import settings
+import cloudinary
+import os
+
+class CloudinaryMigration:
+    """
+    Class to handle the phased migration of Cloudinary images from one acount to another.
+    """
+    def __init__(self):
+        cloudinary.config(
+            cloud_name=settings.TARGET_CLOUDINARY_CLOUD_NAME,
+            api_key=settings.TARGET_CLOUDINARY_API_KEY,
+            api_secret=settings.TARGET_CLOUDINARY_API_SECRET
+        )
+
+        # Temporary directory for downloads
+        self.temp_dir = os.path.join(settings.BASE_DIR, 'temp_cloudinary_images')
+        os.makedirs(self.temp_dir, exist_ok=True)
+
+
+class Command(BaseCommand):
+    help = 'Cloudinary migration utility'
+
+    def add_arguments(self, parser):
+        subparsers = parser.add_subparsers(dest='command', help='Command to run')
+
+        # Initialize migration
+        init_parser = subparsers.add_parser('init', help='Initialize migration')
+
+        # Collect URLs from model
+        collect_model_parser = subparsers.add_parser('collect-model', help='Collect URLs from Django model')
+
+    def handle(self, *args, **options):
+        command = options['command']
+
+        if command == 'init':
+            migration = CloudinaryMigration()
+            self.stdout.write(self.style.SUCCESS('Migration initialized'))

--- a/account/management/commands/cloudinary_migration.py
+++ b/account/management/commands/cloudinary_migration.py
@@ -44,7 +44,7 @@ class CloudinaryMigration:
                 'last_processed_url_index': 0,
                 'last_updated': datetime.now().isoformat(),
                 'model_path': '',
-                'urls': [],
+                'urls': ['', {}],
                 'successful_migrations': {},
                 'failed_migrations': {},
                 'model_updates': 0

--- a/account/management/commands/cloudinary_migration.py
+++ b/account/management/commands/cloudinary_migration.py
@@ -93,10 +93,10 @@ class Command(BaseCommand):
             from django.apps import apps
             model_path = options['model'].split('.')
             if len(model_path) != 2:
-                self.stdout.write(self.style.ERROR(''))
+                self.stdout.write(self.style.ERROR('Model should be in format app.ModelName'))
                 return
 
             app_label, model_name = model_path
             model = apps.get_model(app_label, model_name)
-            url_model_map = migration.collect_urls_from_model(model, options['fields'])
+            url_model_map = migration.collect_urls_from_model(model, options['field'], app_label)
             self.stdout.write(self.style.SUCCESS(f"Collected {len(url_model_map)} URLs from {model_name}"))

--- a/account/management/commands/cloudinary_migration.py
+++ b/account/management/commands/cloudinary_migration.py
@@ -151,21 +151,21 @@ class CloudinaryMigration:
     def process_single_url(self, url_data):
         """Process a single URL, for parallel execution"""
         index, data = url_data
-        temp_path, info = self.download_image(data.url, index)
+        temp_path, info = self.download_image(data['url'], index)
         if temp_path:
-            success, new_url = self.upload_image(temp_path, info, data.url, index)
+            success, new_url = self.upload_image(temp_path, info, data['url'], index)
             return {
                 'index': index,
                 'success': success,
                 'new_url': new_url,
-                'instance_id': data.instance_id
+                'instance_id': data['instance_id']
             }
         
         return {
             'index': index,
             'success': False,
             'new_url': None,
-            'instance_id': data.instance_id
+            'instance_id': data['instance_id']
         }
 
     def migrate_batch(self, start_index=None):

--- a/account/management/commands/cloudinary_migration.py
+++ b/account/management/commands/cloudinary_migration.py
@@ -2,6 +2,7 @@ from django.apps import apps
 from django.core.management.base import BaseCommand
 from django.conf import settings
 from django.db import transaction
+from django_tenants.utils import schema_context, get_tenant_model
 import cloudinary
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
@@ -326,8 +327,13 @@ class Command(BaseCommand):
         elif command == 'collect-model':
             migration = CloudinaryMigration(options['model'])
             app_label, model_name = model_path
-            model = apps.get_model(app_label, model_name)
-            url_model_map = migration.collect_urls_from_model(model, options['model'], options['field'])
+
+            Client = get_tenant_model()
+            tenant = Client.objects.get(schema_name=settings.SCHEMA_NAME)
+
+            with schema_context(tenant.schema_name):
+                model = apps.get_model(app_label, model_name)
+                url_model_map = migration.collect_urls_from_model(model, options['model'], options['field'])
             self.stdout.write(self.style.SUCCESS(f"Collected {len(url_model_map)} URLs from {model_name}"))
 
         elif command == 'migrate-batch':

--- a/cloudinary_migration.sh
+++ b/cloudinary_migration.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+
+# Simple Cloudinary Migration Script
+# This script runs the Cloudinary migration process with user prompts between stages
+
+# Path to Django manage.py
+MANAGE_PY="./manage.py"
+
+# Progress tracking file
+PROGRESS_FILE="cloudinary_migration_progress.txt"
+
+# Models and their image fields to migrate
+MODELS_AND_FIELDS=(
+
+)
+
+# Function to run Django management command
+run_command() {
+    echo "Running: python $MANAGE_PY $1 ${@:2}"
+    python "$MANAGE_PY" "$1" "${@:2}"
+    return $?
+}
+
+# Function to prompt user to continue
+prompt_continue() {
+    echo
+    read -p "Press Enter to continue or Ctrl+C to exit..."
+    echo
+}
+
+# Function to save progress
+save_progress() {
+    echo "$1" > "$PROGRESS_FILE"
+}
+
+# Function to load progress
+load_progress() {
+    if [ -f "$PROGRESS_FILE" ]; then
+        cat "$PROGRESS_FILE"
+    else
+        echo "start"
+    fi
+}
+
+# Main script
+echo "=== Cloudinary Migration Tool ==="
+echo "This script will help you migrate images from one Cloudinary account to another."
+echo "You can exit at any point and resume later by running the script again."
+echo
+
+# Load the current progress
+CURRENT_STAGE=$(load_progress)
+echo "Current progress: $CURRENT_STAGE"
+echo
+
+# Step 0: Initialize migration
+if [ "$CURRENT_STAGE" = "start" ]; then
+    echo "=== STEP 0: INITIALIZING MIGRATION ==="
+    echo "This step will initialize the migration environment."
+
+    for model_field in "${MODELS_AND_FIELDS[@]}"; do
+        # Split the model_field string
+        IFS=':' read -r model field <<< "$model_field"
+
+        echo "Initializing migration for $model"
+        run_command "cloudinary_migration" "init" "$model"
+    done
+
+    save_progress "collect"
+    echo "Initialization complete for all models."
+    prompt_continue
+fi
+
+# Step 1: Collect URLs from models
+if [ "$CURRENT_STAGE" = "collect" ]; then
+    echo "=== STEP 1: COLLECTING URLS ==="
+    
+    for model_field in "${MODELS_AND_FIELDS[@]}"; do
+        # Split the model_field string
+        IFS=':' read -r model field <<< "$model_field"
+        
+        echo "Collecting URLs from $model ($field)"
+        run_command "cloudinary_migration" "collect-model" "$model" "$field"
+        echo "Collection completed for $model"
+        echo
+    done
+    
+    save_progress "migrate"
+    echo "URL collection complete for all models."
+    prompt_continue
+fi
+
+# Step 2: Migrate batches
+if [ "$CURRENT_STAGE" = "migrate" ]; then
+    echo "=== STEP 2: MIGRATING IMAGES ==="
+
+    for model_field in "${MODELS_AND_FIELDS[@]}"; do
+        # Split the model_field string
+        IFS=':' read -r model field <<< "$model_field"
+
+        echo "Starting migration for $model"
+        
+        # Convert model path for state file lookup
+        model_state_prefix=$(echo "$model" | tr '.' '_')
+        state_file="${model_state_prefix}_migration_state.json"
+
+        # Check if the state file exists
+        if [ ! -f "$state_file" ]; then
+            echo "Warning: State file for $model not found. Skipping."
+            continue
+        fi
+
+        # Keep migrating batches until completed
+        status="in_progress"
+        batch_count=0
+
+        while [ "$status" != "completed" ]; do
+            batch_count=$((batch_count + 1))
+            echo "Processing batch #$batch_count for $model"
+
+            # Run the migration batch
+            run_command "cloudinary_migration" "migrate-batch" "$model"
+
+            # Check the status from the state file
+            if [ -f "$state_file" ]; then
+                status=$(grep -o '"status": *"[^"]*"' "$state_file" | cut -d'"' -f4)
+                echo "Current status: $status"
+            else
+                echo "Warning: State file disappeared. Assuming completed."
+                status="completed"
+            fi
+
+            # Ask to continue after each batch
+            echo "Batch #$batch_count for $model completed."
+        done
+
+        echo "Migration completed for $model"
+        echo
+    done
+
+    save_progress "update"
+    echo "Image migration complete for all models."
+    prompt_continue
+fi
+
+# Step 3: Update models
+if [ "$CURRENT_STAGE" = "update" ]; then
+    echo "=== STEP 3: UPDATING MODEL INSTANCES ==="
+    
+    for model_field in "${MODELS_AND_FIELDS[@]}"; do
+        # Split the model_field string
+        IFS=':' read -r model field <<< "$model_field"
+        
+        echo "Updating model instances for $model"
+        run_command "cloudinary_migration" "update-models" "$model"
+        echo "Model update completed for $model"
+        echo
+    done
+    
+    save_progress "cleanup"
+    echo "Model updates complete for all models."
+    prompt_continue
+fi
+
+# Step 4: Cleanup
+if [ "$CURRENT_STAGE" = "cleanup" ]; then
+    echo "=== STEP 4: CLEANING UP ==="
+    echo "Cleaning up temporary files"
+    run_command "cloudinary_migration" "cleanup"
+    
+    save_progress "completed"
+    echo "Cleanup completed."
+    echo
+fi
+
+# Final message
+if [ "$CURRENT_STAGE" = "completed" ] || [ "$(load_progress)" = "completed" ]; then
+    echo "=== MIGRATION COMPLETED ==="
+    echo "The Cloudinary migration process has been completed successfully."
+    # Reset progress file for future runs
+    rm -f "$PROGRESS_FILE"
+else
+    echo "=== MIGRATION IN PROGRESS ==="
+    echo "Current progress: $(load_progress)"
+    echo "Run this script again to continue from this point."
+fi
+
+echo
+echo "Thank you for using the Cloudinary Migration Tool."

--- a/cloudinary_migration.sh
+++ b/cloudinary_migration.sh
@@ -11,7 +11,18 @@ PROGRESS_FILE="cloudinary_migration_progress.txt"
 
 # Models and their image fields to migrate
 MODELS_AND_FIELDS=(
-
+    account.User:photo
+    event.Event:image
+    event.Event:organiserImage
+    extras.MemberPersonalGallery:photo_file
+    extras.Gallery:photo_file
+    extras.ImagesForGalleryV2:image
+    extras.FundAProject:image
+    meeting.Meeting:organiserImage # No data
+    meeting.Meeting:image # No data
+    news.News:image
+    prospectivemember.ManProspectiveMemberFormOne:upload_signature
+    publication.Publication:image
 )
 
 # Function to run Django management command
@@ -67,6 +78,7 @@ if [ "$CURRENT_STAGE" = "start" ]; then
     done
 
     save_progress "collect"
+    CURRENT_STAGE="collect"
     echo "Initialization complete for all models."
     prompt_continue
 fi
@@ -86,6 +98,7 @@ if [ "$CURRENT_STAGE" = "collect" ]; then
     done
     
     save_progress "migrate"
+    CURRENT_STAGE="migrate"
     echo "URL collection complete for all models."
     prompt_continue
 fi
@@ -139,6 +152,7 @@ if [ "$CURRENT_STAGE" = "migrate" ]; then
     done
 
     save_progress "update"
+    CURRENT_STAGE="update"
     echo "Image migration complete for all models."
     prompt_continue
 fi
@@ -169,6 +183,7 @@ if [ "$CURRENT_STAGE" = "cleanup" ]; then
     run_command "cloudinary_migration" "cleanup"
     
     save_progress "completed"
+    CURRENT_STAGE="completed"
     echo "Cleanup completed."
     echo
 fi

--- a/rel8/settings.py
+++ b/rel8/settings.py
@@ -330,6 +330,9 @@ CORS_ALLOW_HEADERS = [
 "usiing cloudinary for storage"
 CLOUDINARY_URL = os.environ["CLOUDINARY_URL"]
 DEFAULT_FILE_STORAGE = "cloudinary_storage.storage.MediaCloudinaryStorage"
+TARGET_CLOUDINARY_CLOUD_NAME = os.environ["TARGET_CLOUDINARY_CLOUD_NAME"]
+TARGET_CLOUDINARY_API_KEY = os.environ["TARGET_CLOUDINARY_API_KEY"]
+TARGET_CLOUDINARY_API_SECRET = os.environ["TARGET_CLOUDINARY_API_SECRET"]
 ASGI_APPLICATION = "rel8.routing.application"
 
 if os.environ.get('REDIS_URL'):

--- a/rel8/settings.py
+++ b/rel8/settings.py
@@ -333,6 +333,7 @@ DEFAULT_FILE_STORAGE = "cloudinary_storage.storage.MediaCloudinaryStorage"
 TARGET_CLOUDINARY_CLOUD_NAME = os.environ["TARGET_CLOUDINARY_CLOUD_NAME"]
 TARGET_CLOUDINARY_API_KEY = os.environ["TARGET_CLOUDINARY_API_KEY"]
 TARGET_CLOUDINARY_API_SECRET = os.environ["TARGET_CLOUDINARY_API_SECRET"]
+SCHEMA_NAME = os.environ["SCHEMA_NAME"]
 ASGI_APPLICATION = "rel8.routing.application"
 
 if os.environ.get('REDIS_URL'):


### PR DESCRIPTION
# Key Changes
- Added a custom Django admin command `cloudinary_migration` to help migrate images from an old Cloudinary account to a new one.
- Includes the following subcommands:
  - `init`: sets up the migration script and config.
  - `collect`-model: pulls image URLs from model fields.
  - `migrate-batch`: downloads images from the old account and uploads them to the new one.
  - `update-models`: updates model instances with new URLs.
  - `cleanup`: clears out temp files and resets the working directory.